### PR TITLE
Corregir visualización de fecha de turnos

### DIFF
--- a/pages/api/appointments.ts
+++ b/pages/api/appointments.ts
@@ -5,7 +5,7 @@ import {
   createAppointmentForAdmin,
   updateAppointmentForAdmin,
   deleteAppointmentForAdmin 
-} from '../../../src/lib/supabase-admin'
+} from '../../src/lib/supabase-admin'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // La autenticación se maneja en el middleware

--- a/src/app/admin/components/AdminDashboard.tsx
+++ b/src/app/admin/components/AdminDashboard.tsx
@@ -26,6 +26,7 @@ import { Fragment } from 'react'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import type { AdminUser } from '../../../lib/admin-auth'
+import { formatDateForDisplay, getTodayString } from '../../../lib/date-utils'
 
 interface AdminDashboardProps {
   adminUser: AdminUser
@@ -115,29 +116,8 @@ export default function AdminDashboard({ adminUser }: AdminDashboardProps) {
   const [availableTimes, setAvailableTimes] = useState<string[]>([])
   const [formLoading, setFormLoading] = useState(false)
   
-  // ✅ SOLUCIÓN DEFINITIVA - Sin crear objetos Date locales
-  const formatYmdStatic = (ymd: string) => {
-    if (!ymd) return ymd
-    
-    try {
-      // Forzar UTC agregando T12:00:00Z para evitar problemas de zona horaria
-      const date = new Date(ymd + 'T12:00:00Z')
-      
-      const weekdays = ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb']
-      const months = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sept', 'oct', 'nov', 'dic']
-      
-      // Usar métodos UTC para evitar conversión de zona horaria
-      const weekday = weekdays[date.getUTCDay()]
-      const month = months[date.getUTCMonth()]
-      const day = date.getUTCDate().toString().padStart(2, '0')
-      const year = date.getUTCFullYear()
-      
-      return `${weekday}, ${day} ${month} ${year}`
-    } catch (error) {
-      console.error('Error formateando fecha:', ymd, error)
-      return ymd
-    }
-  }
+  // Usar función centralizada para formateo de fechas
+  const formatYmdStatic = formatDateForDisplay
   
   // Formulario de crear/editar cita
   const [appointmentForm, setAppointmentForm] = useState<CreateAppointmentForm>({
@@ -905,7 +885,7 @@ export default function AdminDashboard({ adminUser }: AdminDashboardProps) {
                           type="date"
                           value={appointmentForm.appointmentDate}
                           onChange={(e) => handleFormChange('appointmentDate', e.target.value)}
-                          min={new Date().toISOString().split('T')[0]}
+                          min={getTodayString()}
                           className="w-full px-3 py-2 bg-white border-2 border-gray-500 rounded-lg text-gray-900 placeholder-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
                           required
                         />
@@ -1034,7 +1014,7 @@ export default function AdminDashboard({ adminUser }: AdminDashboardProps) {
                           type="date"
                           value={appointmentForm.appointmentDate}
                           onChange={(e) => handleFormChange('appointmentDate', e.target.value)}
-                          min={new Date().toISOString().split('T')[0]}
+                          min={getTodayString()}
                           className="w-full px-3 py-2 bg-white border-2 border-gray-500 rounded-lg text-gray-900 placeholder-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
                           required
                         />

--- a/src/components/AppointmentBooking.tsx
+++ b/src/components/AppointmentBooking.tsx
@@ -5,6 +5,7 @@ import { Dialog, Transition } from '@headlessui/react'
 import { supabase, Doctor } from '../lib/supabase'
 import { format, isSameDay, setHours, setMinutes, addMinutes } from 'date-fns'
 import { es } from 'date-fns/locale'
+import { formatDateForAPI } from '../lib/date-utils'
 import { Fragment } from 'react'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
@@ -36,10 +37,7 @@ const formatName = (name: string): string => {
     .join(' ')
 }
 
-// Función para formatear fecha sin problemas de zona horaria
-const formatDateForAPI = (date: Date): string => {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
-}
+// Usar función centralizada para formateo de fechas
 
 export default function AppointmentBooking({ doctorId, onBack }: AppointmentBookingProps) {
   const [doctor, setDoctor] = useState<Doctor | null>(null)

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,84 @@
+/**
+ * Utilidades para el manejo correcto de fechas sin problemas de zona horaria
+ * Este archivo centraliza todas las funciones de manejo de fechas para evitar
+ * desfases entre la fecha guardada en la base de datos y la mostrada en la UI
+ */
+
+/**
+ * Obtiene la fecha actual en formato YYYY-MM-DD usando la zona horaria local
+ * Evita problemas de desfase que ocurren con toISOString()
+ */
+export function getTodayString(): string {
+  const today = new Date()
+  return `${today.getFullYear()}-${(today.getMonth() + 1).toString().padStart(2, '0')}-${today.getDate().toString().padStart(2, '0')}`
+}
+
+/**
+ * Formatea una fecha en formato YYYY-MM-DD para mostrar en la UI
+ * Sin problemas de zona horaria
+ */
+export function formatDateForDisplay(ymd: string): string {
+  if (!ymd) return ymd
+  
+  try {
+    // Parsear la fecha directamente sin crear objeto Date para evitar conversiones de zona horaria
+    const [year, month, day] = ymd.split('-').map(Number)
+    
+    const weekdays = ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb']
+    const months = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sept', 'oct', 'nov', 'dic']
+    
+    // Crear fecha local directamente para obtener el día de la semana correcto
+    const localDate = new Date(year, month - 1, day)
+    const weekday = weekdays[localDate.getDay()]
+    const monthName = months[month - 1]
+    const dayStr = day.toString().padStart(2, '0')
+    
+    return `${weekday}, ${dayStr} ${monthName} ${year}`
+  } catch (error) {
+    console.error('Error formateando fecha:', ymd, error)
+    return ymd
+  }
+}
+
+/**
+ * Formatea una fecha Date para enviar a la API en formato YYYY-MM-DD
+ * Usa la zona horaria local para evitar desfases
+ */
+export function formatDateForAPI(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Convierte una fecha en formato YYYY-MM-DD a un objeto Date local
+ * Evita problemas de zona horaria al crear el objeto Date
+ */
+export function parseLocalDate(ymd: string): Date {
+  const [year, month, day] = ymd.split('-').map(Number)
+  return new Date(year, month - 1, day)
+}
+
+/**
+ * Obtiene el día de la semana (0-6) para una fecha en formato YYYY-MM-DD
+ * Usando zona horaria local
+ */
+export function getDayOfWeek(ymd: string): number {
+  const localDate = parseLocalDate(ymd)
+  return localDate.getDay()
+}
+
+/**
+ * Valida si una fecha en formato YYYY-MM-DD es válida
+ */
+export function isValidDateString(ymd: string): boolean {
+  if (!ymd || typeof ymd !== 'string') return false
+  
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+  if (!dateRegex.test(ymd)) return false
+  
+  const [year, month, day] = ymd.split('-').map(Number)
+  const date = new Date(year, month - 1, day)
+  
+  return date.getFullYear() === year && 
+         date.getMonth() === month - 1 && 
+         date.getDate() === day
+}

--- a/src/lib/debug-dates-browser.ts
+++ b/src/lib/debug-dates-browser.ts
@@ -1,0 +1,76 @@
+/**
+ * Utilidades de depuración para fechas en el navegador
+ * Este archivo ayuda a identificar problemas de zona horaria en el frontend
+ */
+
+export function debugDateIssues() {
+  console.log('=== DEPURACIÓN DE FECHAS EN NAVEGADOR ===')
+  
+  const testDate = '2024-01-30'
+  console.log('1. Fecha de prueba:', testDate)
+  
+  // Crear objeto Date
+  const dateObj = new Date(testDate)
+  console.log('2. Objeto Date creado:', dateObj.toString())
+  console.log('3. Zona horaria del navegador:', Intl.DateTimeFormat().resolvedOptions().timeZone)
+  console.log('4. Offset en minutos:', dateObj.getTimezoneOffset())
+  console.log('5. Offset en horas:', dateObj.getTimezoneOffset() / 60)
+  
+  // Métodos locales vs UTC
+  console.log('6. Métodos locales:')
+  console.log('   getFullYear():', dateObj.getFullYear())
+  console.log('   getMonth() + 1:', dateObj.getMonth() + 1)
+  console.log('   getDate():', dateObj.getDate())
+  
+  console.log('7. Métodos UTC:')
+  console.log('   getUTCFullYear():', dateObj.getUTCFullYear())
+  console.log('   getUTCMonth() + 1:', dateObj.getUTCMonth() + 1)
+  console.log('   getUTCDate():', dateObj.getUTCDate())
+  
+  // Formateo
+  console.log('8. Formateo:')
+  console.log('   toISOString():', dateObj.toISOString())
+  console.log('   toISOString().split("T")[0]:', dateObj.toISOString().split('T')[0])
+  
+  // Simular el problema
+  const problematicDate = new Date(testDate)
+  const problematicISO = problematicDate.toISOString().split('T')[0]
+  console.log('9. Problema:')
+  console.log(`   Fecha original: ${testDate}`)
+  console.log(`   Después de conversión: ${problematicISO}`)
+  console.log(`   ¿Son iguales? ${testDate === problematicISO}`)
+  
+  if (testDate !== problematicISO) {
+    console.log('   ⚠️ PROBLEMA DETECTADO: Las fechas no coinciden!')
+    const diffDays = Math.floor((new Date(problematicISO).getTime() - new Date(testDate).getTime()) / (1000 * 60 * 60 * 24))
+    console.log(`   Diferencia en días: ${diffDays}`)
+  } else {
+    console.log('   ✅ Las fechas coinciden correctamente')
+  }
+  
+  console.log('=== FIN DE DEPURACIÓN ===')
+}
+
+export function testDateFormatting(ymd: string) {
+  console.log(`\n=== PRUEBA DE FORMATEO PARA: ${ymd} ===`)
+  
+  // Método problemático
+  const problematicDate = new Date(ymd)
+  const problematicFormatted = problematicDate.toISOString().split('T')[0]
+  
+  // Método correcto
+  const [year, month, day] = ymd.split('-').map(Number)
+  const correctFormatted = `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`
+  
+  console.log('Fecha original:', ymd)
+  console.log('Método problemático:', problematicFormatted)
+  console.log('Método correcto:', correctFormatted)
+  console.log('¿Problema detectado?', ymd !== problematicFormatted)
+  
+  return {
+    original: ymd,
+    problematic: problematicFormatted,
+    correct: correctFormatted,
+    hasIssue: ymd !== problematicFormatted
+  }
+}

--- a/src/lib/supabase-admin.ts
+++ b/src/lib/supabase-admin.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import { getTodayString, getDayOfWeek } from './date-utils'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
@@ -195,7 +196,8 @@ export async function getDoctorsForAdmin() {
 }
 
 export async function getAppointmentStats() {
-  const today = new Date().toISOString().split('T')[0]
+  // Obtener fecha de hoy en zona horaria local para evitar desfases
+  const today = getTodayString()
   
   const [
     { count: totalAppointments },
@@ -412,11 +414,8 @@ export async function createPatientForAdmin(patientData: { name: string; email: 
 }
 
 export async function getAvailableTimesForAdmin(doctorId: string, date: string) {
-  // Obtener horario del médico para ese día
-  // Evitar desfase por UTC: construir fecha en horario local a partir de YYYY-MM-DD
-  const [yearStr, monthStr, dayStr] = date.split('-')
-  const localDate = new Date(parseInt(yearStr, 10), parseInt(monthStr, 10) - 1, parseInt(dayStr, 10))
-  const dayOfWeek = localDate.getDay()
+  // Obtener horario del médico para ese día usando función centralizada
+  const dayOfWeek = getDayOfWeek(date)
   
   const { data: schedule } = await supabaseAdmin
     .from('doctor_schedules')


### PR DESCRIPTION
Centralize date utility functions and correct timezone-related date display issues in the admin panel.

The admin panel displayed appointment dates with a one-day delay because `new Date('YYYY-MM-DD')` and `toISOString()` were implicitly using UTC, causing incorrect local timezone conversions. This PR introduces a `date-utils.ts` file with explicit local timezone handling for date parsing, formatting, and API interactions, ensuring dates are consistently displayed and processed correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ea1b452-af87-4c0b-a080-8e6c2f23a629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ea1b452-af87-4c0b-a080-8e6c2f23a629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

